### PR TITLE
Add support for EIP-1102

### DIFF
--- a/src/utils/getWeb3.js
+++ b/src/utils/getWeb3.js
@@ -2,23 +2,41 @@ import Web3 from 'web3'
 
 export const getWeb3 = () => new Promise(function(resolve, reject) {
   // Wait for loading completion to avoid race conditions with web3 injection timing.
-  window.addEventListener('load', function() {
+  window.addEventListener('load', async function() {
     var results
+    var ethereum = window.ethereum
     var web3 = window.web3
 
-    // Checking if Web3 has been injected by the browser (Mist/MetaMask)
-    if (typeof web3 !== 'undefined') {
-      // Use Mist/MetaMask's provider.
+    // Modern dapp browsers...
+    if (typeof ethereum !== 'undefined') {
+        web3 = new Web3(ethereum)
+        try {
+            await ethereum.enable()
+
+            results = {
+              web3: web3
+            }
+
+            console.log('Injected web3 detected.')
+            resolve(results)
+
+        } catch (error) {
+            reject(new Error('User denied account access...'))
+        }
+    }
+    // Legacy dapp browsers...
+    else if (typeof web3 !== 'undefined') {
       web3 = new Web3(web3.currentProvider)
 
       results = {
         web3: web3
       }
 
-      console.log('Injected web3 detected.');
-
+      console.log('Injected web3 detected.')
       resolve(results)
-    } else {
+    }
+    // Non-dapp browsers...
+    else {
       // Fallback to localhost if no web3 injection. We've configured this to
       // use the development console's port by default.
       var provider = new Web3.providers.HttpProvider('http://127.0.0.1:7545')
@@ -29,8 +47,7 @@ export const getWeb3 = () => new Promise(function(resolve, reject) {
         web3: web3
       }
 
-      console.log('No web3 instance injected, using Local web3.');
-
+      console.log('No web3 instance injected, using Local web3.')
       resolve(results)
     }
   })


### PR DESCRIPTION
Add support for privacy mode (EIP-1102). Fix gitcoinco/ethavatar#20.
See https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8 for details.

~This currently calls `ethereum.enable()` in `getWeb3.js` file. You would need to handle denied account access and research if page will load.~
~If the page will freeze during the request, `ethereum.enable()` should be moved to somewhere else (after page is loaded).~

~I will try to figure this out when EIP-1102 will be available in Metamask on web store.~

I tested this and it works file. It requests access after page loads and if it is denied, it says "No Connection To The Ethereum Network".